### PR TITLE
Fix Repository Link in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
 	"publisher": "74th",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/74th/vscode-monokai-charcoal"
+		"url": "https://github.com/74th/vscode-monokaicharcoal"
 	},
-	"homepage": "https://github.com/74th/vscode-monokai-charcoal",
+	"homepage": "https://github.com/74th/vscode-monokaicharcoal",
 	"engines": {
 		"vscode": "^1.28.0"
 	},


### PR DESCRIPTION
This link is incorrect in the package json and subsequently affects the "repository" link in the vscode marketplace extensions info page.